### PR TITLE
- fixed: INPUT_XInput must also be available when compiling without X…

### DIFF
--- a/src/win32/i_input.h
+++ b/src/win32/i_input.h
@@ -47,6 +47,15 @@ FString I_GetFromClipboard (bool windows_has_no_selection_clipboard);
 
 void I_GetEvent();
 
+enum
+{
+	INPUT_DIJoy,
+	INPUT_XInput,
+	INPUT_RawPS2,
+	NUM_JOYDEVICES
+};
+
+
 #ifdef USE_WINDOWS_DWORD
 #include "m_joy.h"
 
@@ -119,14 +128,6 @@ public:
 	virtual void AddAxes(float axes[NUM_JOYAXIS]) = 0;
 	virtual void GetDevices(TArray<IJoystickConfig *> &sticks) = 0;
 	virtual IJoystickConfig *Rescan() = 0;
-};
-
-enum
-{
-	INPUT_DIJoy,
-	INPUT_XInput,
-	INPUT_RawPS2,
-	NUM_JOYDEVICES
 };
 
 extern FJoystickCollection *JoyDevices[NUM_JOYDEVICES];

--- a/src/win32/i_xinput.cpp
+++ b/src/win32/i_xinput.cpp
@@ -789,6 +789,8 @@ void I_StartupXInput()
 
 #else	// NO_XINPUT
 
+#include "i_input.h"
+
 void I_StartupXInput()
 {
 	JoyDevices[INPUT_XInput] = NULL;


### PR DESCRIPTION
…Input support so that the corresponding JoyDevice can be accessed.